### PR TITLE
Add i18n for project, task and collaborator screens

### DIFF
--- a/app/src/main/java/com/example/projetus/AssociarColaboradoresActivity.kt
+++ b/app/src/main/java/com/example/projetus/AssociarColaboradoresActivity.kt
@@ -30,7 +30,7 @@ class AssociarColaboradoresActivity : AppCompatActivity() { // Activity para ass
         projetoId = intent.getIntExtra("projeto_id", -1) // Id do projeto vindo da Intent
 
         if (projetoId == -1) { // Valida projeto
-            Toast.makeText(this, "Projeto inválido", Toast.LENGTH_SHORT).show()
+            Toast.makeText(this, getString(R.string.error_invalid_project), Toast.LENGTH_SHORT).show()
             finish()
             return
         }
@@ -85,22 +85,22 @@ class AssociarColaboradoresActivity : AppCompatActivity() { // Activity para ass
                                     checkBoxes.add(Pair(checkBox, utilizador.id)) // Guarda para posterior uso
                                 }
                             } else {
-                                Toast.makeText(this@AssociarColaboradoresActivity, "Erro ao procurar associados", Toast.LENGTH_SHORT).show()
+                                Toast.makeText(this@AssociarColaboradoresActivity, getString(R.string.error_loading_associated), Toast.LENGTH_SHORT).show()
                             }
                         }
 
                         override fun onFailure(call: Call<UtilizadoresResponse>, t: Throwable) {
-                            Toast.makeText(this@AssociarColaboradoresActivity, "Falha na rede (associados)", Toast.LENGTH_SHORT).show()
+                            Toast.makeText(this@AssociarColaboradoresActivity, getString(R.string.error_network_associated), Toast.LENGTH_SHORT).show()
                         }
                     })
 
                 } else {
-                    Toast.makeText(this@AssociarColaboradoresActivity, "Erro ao carregar utilizadores", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this@AssociarColaboradoresActivity, getString(R.string.error_loading_users), Toast.LENGTH_SHORT).show()
                 }
             }
 
             override fun onFailure(call: Call<UtilizadoresResponse>, t: Throwable) {
-                Toast.makeText(this@AssociarColaboradoresActivity, "Falha na rede (todos)", Toast.LENGTH_SHORT).show()
+                Toast.makeText(this@AssociarColaboradoresActivity, getString(R.string.error_network_users), Toast.LENGTH_SHORT).show()
             }
         })
     } // Fim de carregarUtilizadores
@@ -111,7 +111,7 @@ class AssociarColaboradoresActivity : AppCompatActivity() { // Activity para ass
         val selecionados = checkBoxes.filter { it.first.isChecked }.map { it.second }
 
         if (selecionados.isEmpty()) {
-            Toast.makeText(this, "Selecione pelo menos um colaborador", Toast.LENGTH_SHORT).show()
+            Toast.makeText(this, getString(R.string.error_select_at_least_one_collaborator), Toast.LENGTH_SHORT).show()
             return
         }
 
@@ -129,7 +129,7 @@ class AssociarColaboradoresActivity : AppCompatActivity() { // Activity para ass
             })
         }
 
-        Toast.makeText(this, "Colaboradores associados com sucesso!", Toast.LENGTH_SHORT).show()
+        Toast.makeText(this, getString(R.string.success_collaborators_associated), Toast.LENGTH_SHORT).show()
         finish() // Fecha a Activity após associar
     } // Fim de associarSelecionados
 }

--- a/app/src/main/java/com/example/projetus/CreateProjectActivity.kt
+++ b/app/src/main/java/com/example/projetus/CreateProjectActivity.kt
@@ -54,7 +54,7 @@ class CreateProjectActivity : AppCompatActivity() { // Activity para criar proje
             val gestorId = listaGestores.getOrNull(gestorSelecionado)?.id ?: -1 // Id do gestor
 
             if (nome.isEmpty() || descricao.isEmpty() || dataInicio.isEmpty() || dataFim.isEmpty() || gestorId == -1) {
-                Toast.makeText(this, "Preencha todos os campos e selecione um gestor", Toast.LENGTH_SHORT).show()
+                Toast.makeText(this, getString(R.string.error_fill_all_fields_select_manager), Toast.LENGTH_SHORT).show()
                 return@setOnClickListener
             }
 
@@ -67,7 +67,7 @@ class CreateProjectActivity : AppCompatActivity() { // Activity para criar proje
             ).enqueue(object : Callback<GenericResponse> {
                 override fun onResponse(call: Call<GenericResponse>, response: Response<GenericResponse>) {
                     if (response.isSuccessful && response.body()?.success == true) {
-                        Toast.makeText(this@CreateProjectActivity, "Projeto criado!", Toast.LENGTH_SHORT).show()
+                        Toast.makeText(this@CreateProjectActivity, getString(R.string.success_project_created), Toast.LENGTH_SHORT).show()
                         val resultIntent = Intent()
                         resultIntent.putExtra("project_created", true)
                         setResult(RESULT_OK, resultIntent)
@@ -78,7 +78,7 @@ class CreateProjectActivity : AppCompatActivity() { // Activity para criar proje
                 }
 
                 override fun onFailure(call: Call<GenericResponse>, t: Throwable) {
-                    Toast.makeText(this@CreateProjectActivity, "Erro de conexão", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this@CreateProjectActivity, getString(R.string.error_network), Toast.LENGTH_SHORT).show()
                 }
             })
         }
@@ -98,7 +98,7 @@ class CreateProjectActivity : AppCompatActivity() { // Activity para criar proje
                     adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
                     spinnerGestor.adapter = adapter
                 } else {
-                    Toast.makeText(this@CreateProjectActivity, "Erro ao carregar gestores", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this@CreateProjectActivity, getString(R.string.error_loading_managers), Toast.LENGTH_SHORT).show()
                 }
             }
 

--- a/app/src/main/java/com/example/projetus/CreateTaskActivity.kt
+++ b/app/src/main/java/com/example/projetus/CreateTaskActivity.kt
@@ -57,13 +57,13 @@ class CreateTaskActivity : AppCompatActivity() {
             val estado = spinnerEstado.selectedItem.toString() // Obtém o estado
             val projetoSelecionado = projetosList[spinnerProjetos.selectedItemPosition] // Projeto escolhido
             if (utilizadoresList.isEmpty() || spinnerUtilizadores.selectedItemPosition == -1) {
-                Toast.makeText(this, "Nenhum utilizador selecionado", Toast.LENGTH_SHORT).show()
+                Toast.makeText(this, getString(R.string.error_no_user_selected), Toast.LENGTH_SHORT).show()
                 return@setOnClickListener
             }
             val utilizadorSelecionado = utilizadoresList[spinnerUtilizadores.selectedItemPosition] // Utilizador escolhido
 
             if (nome.isEmpty() || descricao.isEmpty() || dataEntrega.isEmpty()) { // Valida campos obrigatórios
-                Toast.makeText(this, "Preencha todos os campos", Toast.LENGTH_SHORT).show()
+                Toast.makeText(this, getString(R.string.error_fill_all_fields), Toast.LENGTH_SHORT).show()
                 return@setOnClickListener
             }
 
@@ -79,7 +79,7 @@ class CreateTaskActivity : AppCompatActivity() {
             RetrofitClient.instance.addTask(dados).enqueue(object : Callback<GenericResponse> { // Envia para API
                 override fun onResponse(call: Call<GenericResponse>, response: Response<GenericResponse>) { // Resposta
                     if (response.isSuccessful && response.body()?.success == true) {
-                        Toast.makeText(this@CreateTaskActivity, "Tarefa criada com sucesso!", Toast.LENGTH_SHORT).show()
+                        Toast.makeText(this@CreateTaskActivity, getString(R.string.success_task_created), Toast.LENGTH_SHORT).show()
                         finish() // Fecha Activity após sucesso
                     } else {
                         Toast.makeText(this@CreateTaskActivity, response.body()?.message ?: "Erro", Toast.LENGTH_SHORT).show()
@@ -87,7 +87,7 @@ class CreateTaskActivity : AppCompatActivity() {
                 }
 
                 override fun onFailure(call: Call<GenericResponse>, t: Throwable) { // Erro de rede
-                    Toast.makeText(this@CreateTaskActivity, "Erro de conexão", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this@CreateTaskActivity, getString(R.string.error_network), Toast.LENGTH_SHORT).show()
                 }
             })
         }
@@ -108,7 +108,7 @@ class CreateTaskActivity : AppCompatActivity() {
     }
 
     private fun setupEstadoSpinner() {
-        val estados = arrayOf("Pendente", "Concluída")
+        val estados = resources.getStringArray(R.array.task_states)
         spinnerEstado.adapter = ArrayAdapter(this, android.R.layout.simple_spinner_dropdown_item, estados)
     }
 
@@ -137,7 +137,7 @@ class CreateTaskActivity : AppCompatActivity() {
                     val nomes = projetosList.map { it.nome } // Nomes para o spinner
                     spinnerProjetos.adapter = ArrayAdapter(this@CreateTaskActivity, android.R.layout.simple_spinner_dropdown_item, nomes)
                 } else {
-                    Toast.makeText(this@CreateTaskActivity, "Erro ao carregar projetos", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this@CreateTaskActivity, getString(R.string.error_loading_projects), Toast.LENGTH_SHORT).show()
                 }
             }
 
@@ -156,7 +156,7 @@ class CreateTaskActivity : AppCompatActivity() {
                     val nomes = utilizadoresList.map { it.nome }
                     spinnerUtilizadores.adapter = ArrayAdapter(this@CreateTaskActivity, android.R.layout.simple_spinner_dropdown_item, nomes)
                 } else {
-                    Toast.makeText(this@CreateTaskActivity, "Erro ao carregar colaboradores", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this@CreateTaskActivity, getString(R.string.error_loading_collaborators), Toast.LENGTH_SHORT).show()
                 }
             }
 

--- a/app/src/main/res/layout/activity_associar_colaboradores.xml
+++ b/app/src/main/res/layout/activity_associar_colaboradores.xml
@@ -10,7 +10,7 @@
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Selecionar Colaboradores"
+        android:text="@string/title_select_collaborators"
         android:textSize="24sp"
         android:textStyle="bold"
         android:textColor="#212121"
@@ -49,7 +49,7 @@
             android:layout_width="0dp"
             android:layout_height="50dp"
             android:layout_weight="1"
-            android:text="Cancelar"
+            android:text="@string/action_cancel"
             android:textAllCaps="false"
             android:textColor="#FFFFFF"
             android:backgroundTint="#EF5350"
@@ -60,7 +60,7 @@
             android:layout_width="0dp"
             android:layout_height="50dp"
             android:layout_weight="1"
-            android:text="Associar"
+            android:text="@string/action_associate"
             android:textAllCaps="false"
             android:textColor="#FFFFFF"
             android:backgroundTint="#4CAF50" />

--- a/app/src/main/res/layout/activity_create_project.xml
+++ b/app/src/main/res/layout/activity_create_project.xml
@@ -10,7 +10,7 @@
         android:orientation="vertical">
 
         <TextView
-            android:text="Criar Projeto"
+            android:text="@string/title_create_project"
             android:textSize="24sp"
             android:textStyle="bold"
             android:layout_marginBottom="24dp"
@@ -21,7 +21,7 @@
         <!-- Nome do projeto -->
         <EditText
             android:id="@+id/et_nome_projeto"
-            android:hint="Nome do Projeto"
+            android:hint="@string/hint_project_name"
             android:padding="12dp"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -31,7 +31,7 @@
         <!-- Descrição -->
         <EditText
             android:id="@+id/et_descricao_projeto"
-            android:hint="Descrição"
+            android:hint="@string/hint_description"
             android:inputType="textMultiLine"
             android:minLines="3"
             android:padding="12dp"
@@ -44,7 +44,7 @@
         <!-- Data início -->
         <EditText
             android:id="@+id/et_data_inicio"
-            android:hint="Data de Início"
+            android:hint="@string/hint_start_date"
             android:focusable="false"
             android:padding="12dp"
             android:layout_width="match_parent"
@@ -55,7 +55,7 @@
         <!-- Data fim -->
         <EditText
             android:id="@+id/et_data_fim"
-            android:hint="Data de Fim"
+            android:hint="@string/hint_end_date"
             android:focusable="false"
             android:padding="12dp"
             android:layout_width="match_parent"
@@ -67,7 +67,7 @@
         <TextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Selecionar Gestor do Projeto"
+            android:text="@string/label_select_project_manager"
             android:textSize="16sp"
             android:textColor="#333333"
             android:layout_marginBottom="4dp" />
@@ -90,7 +90,7 @@
 
             <Button
                 android:id="@+id/btn_cancelar_projeto"
-                android:text="Cancelar"
+                android:text="@string/action_cancel"
                 android:layout_width="0dp"
                 android:layout_height="48dp"
                 android:layout_weight="1"
@@ -103,7 +103,7 @@
 
             <Button
                 android:id="@+id/btn_guardar_projeto"
-                android:text="Guardar"
+                android:text="@string/action_save"
                 android:layout_width="0dp"
                 android:layout_height="48dp"
                 android:layout_weight="1"

--- a/app/src/main/res/layout/activity_create_task.xml
+++ b/app/src/main/res/layout/activity_create_task.xml
@@ -12,7 +12,7 @@
         android:gravity="center_horizontal">
 
         <TextView
-            android:text="Criar Tarefa"
+            android:text="@string/title_create_task"
             android:textSize="24sp"
             android:textStyle="bold"
             android:textColor="#333333"
@@ -25,7 +25,7 @@
             android:id="@+id/et_nome"
             android:layout_width="match_parent"
             android:layout_height="50dp"
-            android:hint="Nome da Tarefa"
+            android:hint="@string/hint_task_name"
             android:background="@android:drawable/edit_text"
             android:padding="12dp"
             android:layout_marginBottom="12dp"/>
@@ -35,7 +35,7 @@
             android:id="@+id/et_descricao"
             android:layout_width="match_parent"
             android:layout_height="100dp"
-            android:hint="Descrição"
+            android:hint="@string/hint_description"
             android:background="@android:drawable/edit_text"
             android:padding="12dp"
             android:gravity="top"
@@ -66,7 +66,7 @@
             android:id="@+id/et_data_entrega"
             android:layout_width="match_parent"
             android:layout_height="50dp"
-            android:hint="Data de Entrega"
+            android:hint="@string/hint_delivery_date"
             android:focusable="false"
             android:background="@android:drawable/edit_text"
             android:padding="12dp"
@@ -93,7 +93,7 @@
                 android:layout_width="0dp"
                 android:layout_height="50dp"
                 android:layout_weight="1"
-                android:text="Cancelar"
+                android:text="@string/action_cancel"
                 android:textColor="#FFFFFF"
                 android:backgroundTint="#F44336"
                 android:layout_marginEnd="8dp" />
@@ -103,7 +103,7 @@
                 android:layout_width="0dp"
                 android:layout_height="50dp"
                 android:layout_weight="1"
-                android:text="Guardar"
+                android:text="@string/action_save"
                 android:textColor="#FFFFFF"
                 android:backgroundTint="#4CAF50" />
         </LinearLayout>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -66,4 +66,42 @@
     <string name="error_write_question">Write your question</string>
     <string name="message_sent">Message sent</string>
     <string name="error_sending_message">Error sending message</string>
+
+    <!-- Associate Collaborators -->
+    <string name="error_invalid_project">Invalid project</string>
+    <string name="error_loading_associated">Error fetching associated users</string>
+    <string name="error_network_associated">Network failure (associates)</string>
+    <string name="error_loading_users">Error loading users</string>
+    <string name="error_network_users">Network failure (all)</string>
+    <string name="error_select_at_least_one_collaborator">Select at least one collaborator</string>
+    <string name="success_collaborators_associated">Collaborators successfully associated!</string>
+
+    <!-- Create Project -->
+    <string name="error_fill_all_fields_select_manager">Fill all fields and select a manager</string>
+    <string name="success_project_created">Project created!</string>
+    <string name="error_loading_managers">Error loading managers</string>
+
+    <!-- Create Task -->
+    <string name="error_no_user_selected">No user selected</string>
+    <string name="success_task_created">Task created successfully!</string>
+    <string name="error_loading_projects">Error loading projects</string>
+    <string name="error_loading_collaborators">Error loading collaborators</string>
+
+    <!-- Titles and hints -->
+    <string name="title_select_collaborators">Select Collaborators</string>
+    <string name="action_associate">Associate</string>
+    <string name="title_create_project">Create Project</string>
+    <string name="hint_project_name">Project Name</string>
+    <string name="hint_description">Description</string>
+    <string name="hint_start_date">Start Date</string>
+    <string name="hint_end_date">End Date</string>
+    <string name="label_select_project_manager">Select Project Manager</string>
+    <string name="title_create_task">Create Task</string>
+    <string name="hint_task_name">Task Name</string>
+    <string name="hint_delivery_date">Delivery Date</string>
+
+    <string-array name="task_states">
+        <item>Pending</item>
+        <item>Completed</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -67,4 +67,42 @@
     <string name="error_write_question">Escreva a sua dúvida</string>
     <string name="message_sent">Mensagem enviada</string>
     <string name="error_sending_message">Erro ao enviar mensagem</string>
+
+    <!-- Associação de Colaboradores -->
+    <string name="error_invalid_project">Projeto inválido</string>
+    <string name="error_loading_associated">Erro ao procurar associados</string>
+    <string name="error_network_associated">Falha na rede (associados)</string>
+    <string name="error_loading_users">Erro ao carregar utilizadores</string>
+    <string name="error_network_users">Falha na rede (todos)</string>
+    <string name="error_select_at_least_one_collaborator">Selecione pelo menos um colaborador</string>
+    <string name="success_collaborators_associated">Colaboradores associados com sucesso!</string>
+
+    <!-- Criação de Projeto -->
+    <string name="error_fill_all_fields_select_manager">Preencha todos os campos e selecione um gestor</string>
+    <string name="success_project_created">Projeto criado!</string>
+    <string name="error_loading_managers">Erro ao carregar gestores</string>
+
+    <!-- Criação de Tarefa -->
+    <string name="error_no_user_selected">Nenhum utilizador selecionado</string>
+    <string name="success_task_created">Tarefa criada com sucesso!</string>
+    <string name="error_loading_projects">Erro ao carregar projetos</string>
+    <string name="error_loading_collaborators">Erro ao carregar colaboradores</string>
+
+    <!-- Títulos e dicas -->
+    <string name="title_select_collaborators">Selecionar Colaboradores</string>
+    <string name="action_associate">Associar</string>
+    <string name="title_create_project">Criar Projeto</string>
+    <string name="hint_project_name">Nome do Projeto</string>
+    <string name="hint_description">Descrição</string>
+    <string name="hint_start_date">Data de Início</string>
+    <string name="hint_end_date">Data de Fim</string>
+    <string name="label_select_project_manager">Selecionar Gestor do Projeto</string>
+    <string name="title_create_task">Criar Tarefa</string>
+    <string name="hint_task_name">Nome da Tarefa</string>
+    <string name="hint_delivery_date">Data de Entrega</string>
+
+    <string-array name="task_states">
+        <item>Pendente</item>
+        <item>Concluída</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
## Summary
- enable English/Portuguese strings for Create Project, Create Task and collaborator association screens
- translate layouts and use string resources in Kotlin code
- add translations in `values` and `values-en`

## Testing
- `./gradlew test` *(fails: unable to download Gradle wrapper)*

------
https://chatgpt.com/codex/tasks/task_e_684ee909a30483329470ea66a75f8714