### PR TITLE
Add multilingual support for project screens

### DIFF
--- a/app/src/main/java/com/example/projetus/ProjectDetailsActivity.kt
+++ b/app/src/main/java/com/example/projetus/ProjectDetailsActivity.kt
@@ -40,10 +40,10 @@ class ProjectDetailsActivity : AppCompatActivity() { // Activity com detalhes do
         val projeto = intent.getSerializableExtra("projeto") as? Project // Projeto recebido na intent
 
         if (projeto != null) { // Se foi passado um projeto
-            nome.text = "Nome: ${projeto.nome}" // Mostra nome
-            descricao.text = "Descrição: ${projeto.descricao}" // Mostra descrição
-            inicio.text = "Início: ${projeto.data_inicio}" // Mostra data início
-            fim.text = "Fim: ${projeto.data_fim}" // Mostra data fim
+            nome.text = getString(R.string.label_project_name) + " ${projeto.nome}"
+            descricao.text = getString(R.string.label_project_description) + " ${projeto.descricao}"
+            inicio.text = getString(R.string.label_start) + " ${projeto.data_inicio}"
+            fim.text = getString(R.string.label_end) + " ${projeto.data_fim}"
             gestor.setText(projeto.gestor_nome) // Mostra gestor
             val totalSegundos = projeto.tempo_total_segundos // Converte tempo total
             val horas = totalSegundos / 3600 // Horas totais
@@ -84,15 +84,15 @@ class ProjectDetailsActivity : AppCompatActivity() { // Activity com detalhes do
         RetrofitClient.instance.getColaboradoresDoProjeto(data).enqueue(object : Callback<UtilizadoresResponse> { // Chamada para obter colaboradores
             override fun onResponse(call: Call<UtilizadoresResponse>, response: Response<UtilizadoresResponse>) {
                 if (response.isSuccessful && response.body()?.success == true) {
-                    val nomes = response.body()?.utilizadores?.joinToString(", ") { it.nome } ?: "Nenhum" // Junta nomes
+                    val nomes = response.body()?.utilizadores?.joinToString(", ") { it.nome } ?: getString(R.string.none)
                     colaboradoresTv.text = nomes
                 } else {
-                    colaboradoresTv.text = "Erro ao carregar" // Caso de erro
+                    colaboradoresTv.text = getString(R.string.msg_error_loading_data)
                 }
             }
 
             override fun onFailure(call: Call<UtilizadoresResponse>, t: Throwable) { // Falha de rede
-                colaboradoresTv.text = "Falha na rede"
+                colaboradoresTv.text = getString(R.string.error_network)
             }
         })
 
@@ -102,15 +102,15 @@ class ProjectDetailsActivity : AppCompatActivity() { // Activity com detalhes do
                 RetrofitClient.instance.apagarProjeto(data).enqueue(object : Callback<SimpleResponse> {
                     override fun onResponse(call: Call<SimpleResponse>, response: Response<SimpleResponse>) {
                         if (response.isSuccessful && response.body()?.success == true) {
-                            Toast.makeText(this@ProjectDetailsActivity, "Projeto apagado com sucesso", Toast.LENGTH_SHORT).show()
+                            Toast.makeText(this@ProjectDetailsActivity, getString(R.string.msg_project_deleted_success), Toast.LENGTH_SHORT).show()
                             finish() // Fecha a activity
                         } else {
-                            Toast.makeText(this@ProjectDetailsActivity, "Erro ao apagar projeto", Toast.LENGTH_SHORT).show()
+                            Toast.makeText(this@ProjectDetailsActivity, getString(R.string.msg_project_delete_error), Toast.LENGTH_SHORT).show()
                         }
                     }
 
                     override fun onFailure(call: Call<SimpleResponse>, t: Throwable) {
-                        Toast.makeText(this@ProjectDetailsActivity, "Erro de conexão", Toast.LENGTH_SHORT).show()
+                        Toast.makeText(this@ProjectDetailsActivity, getString(R.string.error_network), Toast.LENGTH_SHORT).show()
                     }
                 })
             }

--- a/app/src/main/java/com/example/projetus/ProjectEvaluationActivity.kt
+++ b/app/src/main/java/com/example/projetus/ProjectEvaluationActivity.kt
@@ -32,7 +32,7 @@ class ProjectEvaluationActivity : AppCompatActivity() { // Activity para avaliar
         projectId = intent.getIntExtra("projeto_id", -1) // Lê ID do projeto
 
         if (userId == -1 || projectId == -1) { // Verifica se IDs são válidos
-            Toast.makeText(this, "Dados do projeto inválidos", Toast.LENGTH_SHORT).show()
+            Toast.makeText(this, getString(R.string.msg_invalid_project_data), Toast.LENGTH_SHORT).show()
             finish()
             return
         }
@@ -114,12 +114,12 @@ class ProjectEvaluationActivity : AppCompatActivity() { // Activity para avaliar
                         }
 
                     } else {
-                        Toast.makeText(this@ProjectEvaluationActivity, "Erro ao carregar dados", Toast.LENGTH_SHORT).show()
+                        Toast.makeText(this@ProjectEvaluationActivity, getString(R.string.msg_error_loading_data), Toast.LENGTH_SHORT).show()
                     }
                 }
 
                 override fun onFailure(call: Call<AvaliacoesResponse>, t: Throwable) { // Erro de rede
-                    Toast.makeText(this@ProjectEvaluationActivity, "Erro de rede", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this@ProjectEvaluationActivity, getString(R.string.error_network), Toast.LENGTH_SHORT).show()
                 }
             })
     }
@@ -154,18 +154,18 @@ class ProjectEvaluationActivity : AppCompatActivity() { // Activity para avaliar
                         Log.d("Avaliacao", "Resposta OK: ${response.body()}")
                     } else {
                         Log.e("Avaliacao", "Erro na resposta: ${response.errorBody()?.string()}")
-                        Toast.makeText(this@ProjectEvaluationActivity, "Erro ao guardar avaliação", Toast.LENGTH_SHORT).show()
+                        Toast.makeText(this@ProjectEvaluationActivity, getString(R.string.msg_error_saving_evaluation), Toast.LENGTH_SHORT).show()
                     }
                 }
 
                 override fun onFailure(call: Call<SimpleResponse>, t: Throwable) {
                     Log.e("Avaliacao", "Erro de rede", t)
-                    Toast.makeText(this@ProjectEvaluationActivity, "Erro de rede", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this@ProjectEvaluationActivity, getString(R.string.error_network), Toast.LENGTH_SHORT).show()
                 }
             })
         }
 
-        Toast.makeText(this, "Avaliações guardadas!", Toast.LENGTH_SHORT).show() // Confirmação
+        Toast.makeText(this, getString(R.string.msg_evaluations_saved), Toast.LENGTH_SHORT).show() // Confirmação
     }
 
 
@@ -175,15 +175,15 @@ class ProjectEvaluationActivity : AppCompatActivity() { // Activity para avaliar
         RetrofitClient.instance.concluirProjeto(data).enqueue(object : Callback<SimpleResponse> {
             override fun onResponse(call: Call<SimpleResponse>, response: Response<SimpleResponse>) {
                 if (response.isSuccessful && response.body()?.success == true) {
-                    Toast.makeText(this@ProjectEvaluationActivity, "Projeto concluído!", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this@ProjectEvaluationActivity, getString(R.string.msg_project_completed), Toast.LENGTH_SHORT).show()
                     finish()
                 } else {
-                    Toast.makeText(this@ProjectEvaluationActivity, "Erro ao concluir projeto", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this@ProjectEvaluationActivity, getString(R.string.msg_error_completing_project), Toast.LENGTH_SHORT).show()
                 }
             }
 
             override fun onFailure(call: Call<SimpleResponse>, t: Throwable) {
-                Toast.makeText(this@ProjectEvaluationActivity, "Erro de rede", Toast.LENGTH_SHORT).show()
+                Toast.makeText(this@ProjectEvaluationActivity, getString(R.string.error_network), Toast.LENGTH_SHORT).show()
             }
         })
     }

--- a/app/src/main/java/com/example/projetus/ProjectsActivity.kt
+++ b/app/src/main/java/com/example/projetus/ProjectsActivity.kt
@@ -25,7 +25,7 @@ class ProjectsActivity : AppCompatActivity() { // Activity que lista projetos
         val tipoPerfil = intent.getStringExtra("tipo_perfil") ?: "utilizador" // Tipo de perfil
 
         if (userId == -1) { // Caso não haja utilizador válido
-            Toast.makeText(this, "Utilizador não autenticado", Toast.LENGTH_SHORT).show()
+            Toast.makeText(this, getString(R.string.msg_user_not_authenticated), Toast.LENGTH_SHORT).show()
             finish()
             return
         }
@@ -80,12 +80,12 @@ class ProjectsActivity : AppCompatActivity() { // Activity que lista projetos
                     } ?: emptyList()
                     renderProjects(projetos) // Mostra apenas projetos ativos
                 } else {
-                    Toast.makeText(this@ProjectsActivity, "Erro ao carregar projetos", Toast.LENGTH_SHORT).show()
-                }
+                    Toast.makeText(this@ProjectsActivity, getString(R.string.msg_error_loading_projects), Toast.LENGTH_SHORT).show()
+            }
             }
 
             override fun onFailure(call: Call<ProjectResponse>, t: Throwable) {
-                Toast.makeText(this@ProjectsActivity, "Erro: ${t.message}", Toast.LENGTH_LONG).show()
+                Toast.makeText(this@ProjectsActivity, getString(R.string.error_generic, t.message ?: ""), Toast.LENGTH_LONG).show()
             }
         })
     }
@@ -100,12 +100,15 @@ class ProjectsActivity : AppCompatActivity() { // Activity que lista projetos
             val tipoPerfil = intent.getStringExtra("tipo_perfil") ?: "utilizador"
 
             view.findViewById<TextView>(R.id.tv_project_name).text = projeto.nome
-            view.findViewById<TextView>(R.id.tv_project_manager).text = "Gestor: ${projeto.gestor_nome}"
-            view.findViewById<TextView>(R.id.tv_project_status).text = "Estado: ${projeto.estado}"
-            view.findViewById<TextView>(R.id.tv_task_count).text = "${projeto.total_tarefas} tarefas"
+            view.findViewById<TextView>(R.id.tv_project_manager).text =
+                getString(R.string.label_project_manager, projeto.gestor_nome)
+            view.findViewById<TextView>(R.id.tv_project_status).text =
+                getString(R.string.label_project_status, projeto.estado)
+            view.findViewById<TextView>(R.id.tv_task_count).text =
+                getString(R.string.label_project_tasks, projeto.total_tarefas)
 
             val btn = view.findViewById<Button>(R.id.btn_project_action) // Botão principal do card
-            btn.text = if (userId == 1) "Editar" else "Ver"
+            btn.text = if (userId == 1) getString(R.string.action_edit) else getString(R.string.action_view)
             btn.setOnClickListener {
                 val intent = Intent(this, ProjectDetailsActivity::class.java)
                 intent.putExtra("projeto", projeto)

--- a/app/src/main/res/layout/activity_project_details.xml
+++ b/app/src/main/res/layout/activity_project_details.xml
@@ -20,7 +20,7 @@
             <TextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Detalhes do Projeto"
+                android:text="@string/title_project_details"
                 android:textStyle="bold"
                 android:textSize="24sp"
                 android:textColor="#212121"
@@ -31,7 +31,7 @@
                 android:id="@+id/tv_nome"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Nome do Projeto:"
+                android:text="@string/label_project_name"
                 android:textSize="16sp"
                 android:textColor="#333333"
                 android:layout_marginBottom="8dp" />
@@ -40,7 +40,7 @@
                 android:id="@+id/tv_descricao"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Descrição do Projeto:"
+                android:text="@string/label_project_description"
                 android:textSize="16sp"
                 android:textColor="#333333"
                 android:layout_marginBottom="8dp" />
@@ -49,7 +49,7 @@
                 android:id="@+id/tv_inicio"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Início:"
+                android:text="@string/label_start"
                 android:textSize="16sp"
                 android:textColor="#333333"
                 android:layout_marginBottom="8dp" />
@@ -58,7 +58,7 @@
                 android:id="@+id/tv_fim"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Fim:"
+                android:text="@string/label_end"
                 android:textSize="16sp"
                 android:textColor="#333333"
                 android:layout_marginBottom="16dp" />
@@ -67,7 +67,7 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Gestor:"
+                android:text="@string/label_manager_plain"
                 android:textStyle="bold"
                 android:textColor="#000000"
                 android:layout_marginBottom="4dp" />
@@ -87,7 +87,7 @@
                 android:id="@+id/tv_colaboradores_title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Colaboradores:"
+                android:text="@string/label_collaborators"
                 android:textStyle="bold"
                 android:textColor="#000000"
                 android:layout_marginBottom="4dp" />
@@ -96,7 +96,7 @@
                 android:id="@+id/tv_colaboradores"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="(a carregar...)"
+                android:text="@string/loading_collaborators"
                 android:textColor="#666"
                 android:background="#EEEEEE"
                 android:padding="12dp"
@@ -106,7 +106,7 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Taxa de Conclusão:"
+                android:text="@string/label_completion_rate"
                 android:textStyle="bold"
                 android:layout_marginBottom="8dp" />
 
@@ -141,7 +141,7 @@
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Tempo Gasto:"
+                android:text="@string/label_time_spent"
                 android:textStyle="bold"
                 android:layout_marginBottom="4dp" />
 
@@ -161,7 +161,7 @@
                 android:id="@+id/btn_associar_colaboradores"
                 android:layout_width="match_parent"
                 android:layout_height="50dp"
-                android:text="Associar Colaboradores"
+                android:text="@string/action_associate_collaborators"
                 android:backgroundTint="#1976D2"
                 android:textColor="#FFFFFF"
                 android:textAllCaps="false"
@@ -171,7 +171,7 @@
                 android:id="@+id/btn_concluir"
                 android:layout_width="match_parent"
                 android:layout_height="50dp"
-                android:text="Marcar como concluído"
+                android:text="@string/action_mark_completed"
                 android:backgroundTint="#4CAF50"
                 android:textColor="#FFFFFF"
                 android:textAllCaps="false" />
@@ -180,7 +180,7 @@
                 android:id="@+id/btn_apagar"
                 android:layout_width="match_parent"
                 android:layout_height="50dp"
-                android:text="Apagar Projeto"
+                android:text="@string/action_delete_project"
                 android:backgroundTint="#F44336"
                 android:textColor="#FFFFFF"
                 android:textAllCaps="false"
@@ -207,7 +207,7 @@
             android:layout_height="48dp"
             android:layout_weight="1"
             android:src="@drawable/ic_home"
-            android:contentDescription="Home"
+            android:contentDescription="@string/desc_home"
             android:scaleType="centerInside"
             android:padding="8dp" />
 
@@ -217,7 +217,7 @@
             android:layout_height="48dp"
             android:layout_weight="1"
             android:src="@drawable/ic_user"
-            android:contentDescription="Perfil"
+            android:contentDescription="@string/desc_profile"
             android:scaleType="centerInside"
             android:padding="8dp" />
 
@@ -227,7 +227,7 @@
             android:layout_height="48dp"
             android:layout_weight="1"
             android:src="@drawable/ic_settings"
-            android:contentDescription="Definições"
+            android:contentDescription="@string/desc_settings"
             android:scaleType="centerInside"
             android:padding="8dp" />
     </LinearLayout>

--- a/app/src/main/res/layout/activity_project_evaluation.xml
+++ b/app/src/main/res/layout/activity_project_evaluation.xml
@@ -11,7 +11,7 @@
         android:id="@+id/tv_titulo_avaliacao"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Avaliar Performance"
+        android:text="@string/title_evaluate_performance"
         android:textSize="22sp"
         android:textStyle="bold"
         android:textColor="#000000"
@@ -33,7 +33,7 @@
         android:id="@+id/btn_guardar_avaliacao"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Guardar Avaliação"
+        android:text="@string/action_save_evaluation"
         android:backgroundTint="#2196F3"
         android:textColor="#FFFFFF"
         android:layout_marginTop="8dp" />
@@ -42,7 +42,7 @@
         android:id="@+id/btn_concluir_projeto"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="Marcar projeto como concluído"
+        android:text="@string/action_mark_project_complete"
         android:backgroundTint="#4CAF50"
         android:textColor="#FFFFFF"
         android:layout_marginTop="8dp" />
@@ -61,7 +61,7 @@
             android:layout_height="48dp"
             android:layout_weight="1"
             android:src="@drawable/ic_home"
-            android:contentDescription="Home"
+            android:contentDescription="@string/desc_home"
             android:scaleType="centerInside"
             android:padding="8dp"/>
 
@@ -71,7 +71,7 @@
             android:layout_height="48dp"
             android:layout_weight="1"
             android:src="@drawable/ic_user"
-            android:contentDescription="Perfil"
+            android:contentDescription="@string/desc_profile"
             android:scaleType="centerInside"
             android:padding="8dp"/>
 
@@ -81,7 +81,7 @@
             android:layout_height="48dp"
             android:layout_weight="1"
             android:src="@drawable/ic_settings"
-            android:contentDescription="Configurações"
+            android:contentDescription="@string/desc_settings"
             android:scaleType="centerInside"
             android:padding="8dp"/>
     </LinearLayout>

--- a/app/src/main/res/layout/activity_projects.xml
+++ b/app/src/main/res/layout/activity_projects.xml
@@ -9,7 +9,7 @@
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Projetos"
+        android:text="@string/title_projects"
         android:textSize="24sp"
         android:textStyle="bold"
         android:layout_marginBottom="16dp" />
@@ -36,7 +36,7 @@
                 android:id="@+id/btn_add_project"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="Adicionar projeto"
+                android:text="@string/action_add_project"
                 android:backgroundTint="#FF4081"
                 android:textColor="#FFFFFF"
                 android:layout_marginTop="16dp"
@@ -58,7 +58,7 @@
             android:layout_height="48dp"
             android:layout_weight="1"
             android:src="@drawable/ic_home"
-            android:contentDescription="Home"
+            android:contentDescription="@string/desc_home"
             android:scaleType="centerInside" />
 
         <ImageView
@@ -67,7 +67,7 @@
             android:layout_height="48dp"
             android:layout_weight="1"
             android:src="@drawable/ic_user"
-            android:contentDescription="Perfil"
+            android:contentDescription="@string/desc_profile"
             android:scaleType="centerInside" />
 
         <ImageView
@@ -76,7 +76,7 @@
             android:layout_height="48dp"
             android:layout_weight="1"
             android:src="@drawable/ic_settings"
-            android:contentDescription="Definições"
+            android:contentDescription="@string/desc_settings"
             android:scaleType="centerInside" />
     </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/item_avaliacao.xml
+++ b/app/src/main/res/layout/item_avaliacao.xml
@@ -12,7 +12,7 @@
         android:id="@+id/tv_nome_colaborador"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="João Silva  Criar Interface"
+        android:text="@string/hint_collaborator_task"
         android:textStyle="bold"
         android:textSize="16sp"
         android:textColor="#000000"/>
@@ -20,7 +20,7 @@
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Nota:"
+        android:text="@string/label_rating"
         android:layout_marginTop="6dp"
         android:textColor="#333"/>
 
@@ -37,7 +37,7 @@
         android:id="@+id/et_comentario"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:hint="Comentário"
+        android:hint="@string/hint_comment"
         android:background="@drawable/rounded_edittext"
         android:padding="8dp"
         android:layout_marginTop="8dp"/>

--- a/app/src/main/res/layout/item_project.xml
+++ b/app/src/main/res/layout/item_project.xml
@@ -19,7 +19,7 @@
             android:id="@+id/tv_project_name"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Nome do Projeto"
+            android:text="@string/label_project_name"
             android:textSize="18sp"
             android:textStyle="bold"
             android:textColor="#333333"
@@ -29,7 +29,7 @@
             android:id="@+id/tv_project_manager"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Gestor: Nome"
+            android:text="@string/label_project_manager"
             android:textSize="14sp"
             android:textColor="#666666" />
 
@@ -37,7 +37,7 @@
             android:id="@+id/tv_project_status"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Estado: Ativo"
+            android:text="@string/label_project_status"
             android:textSize="14sp"
             android:textColor="#666666" />
 
@@ -45,7 +45,7 @@
             android:id="@+id/tv_task_count"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="12 tarefas"
+            android:text="@string/label_project_tasks"
             android:textSize="14sp"
             android:textColor="#666666"
             android:layout_marginBottom="12dp" />
@@ -60,7 +60,7 @@
                 android:id="@+id/btn_project_action"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Ver"
+                android:text="@string/action_view"
                 android:textAllCaps="false"
                 android:textColor="#FFFFFF"
                 android:backgroundTint="#7E57C2"
@@ -72,7 +72,7 @@
                 android:id="@+id/btn_ver_tarefas"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Ver Tarefas"
+                android:text="@string/action_view_tasks"
                 android:textAllCaps="false"
                 android:textColor="#FFFFFF"
                 android:backgroundTint="#5C6BC0"

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -114,4 +114,48 @@
     <string name="label_manager">Manager: %1$s</string>
     <string name="label_status">Status: %1$s</string>
     <string name="label_task_count">%1$d tasks</string>
+
+    <!-- Project Details -->
+    <string name="title_project_details">Project Details</string>
+    <string name="label_project_name">Project Name:</string>
+    <string name="label_project_description">Project Description:</string>
+    <string name="label_start">Start:</string>
+    <string name="label_end">End:</string>
+    <string name="label_manager_plain">Manager:</string>
+    <string name="label_collaborators">Collaborators:</string>
+    <string name="loading_collaborators">(loading...)</string>
+    <string name="label_completion_rate">Completion Rate:</string>
+    <string name="label_time_spent">Time Spent:</string>
+    <string name="action_associate_collaborators">Associate Collaborators</string>
+    <string name="action_mark_completed">Mark as completed</string>
+    <string name="action_delete_project">Delete Project</string>
+    <string name="msg_project_deleted_success">Project deleted successfully</string>
+    <string name="msg_project_delete_error">Error deleting project</string>
+
+    <!-- Project Evaluation -->
+    <string name="title_evaluate_performance">Evaluate Performance</string>
+    <string name="action_save_evaluation">Save Evaluation</string>
+    <string name="action_mark_project_complete">Mark project as completed</string>
+    <string name="msg_invalid_project_data">Invalid project data</string>
+    <string name="msg_error_loading_data">Error loading data</string>
+    <string name="msg_error_saving_evaluation">Error saving evaluation</string>
+    <string name="msg_evaluations_saved">Evaluations saved!</string>
+    <string name="msg_project_completed">Project completed!</string>
+    <string name="msg_error_completing_project">Error completing project</string>
+
+    <!-- Projects List -->
+    <string name="title_projects">Projects</string>
+    <string name="action_add_project">Add project</string>
+    <string name="msg_user_not_authenticated">User not authenticated</string>
+    <string name="msg_error_loading_projects">Error loading projects</string>
+    <string name="label_project_manager">Manager: %1$s</string>
+    <string name="label_project_status">Status: %1$s</string>
+    <string name="label_project_tasks">%1$d tasks</string>
+    <string name="action_view">View</string>
+    <string name="action_edit">Edit</string>
+    <string name="action_view_tasks">View Tasks</string>
+    <string name="label_rating">Rating:</string>
+    <string name="hint_comment">Comment</string>
+    <string name="hint_collaborator_task">Name - Task</string>
+    <string name="none">None</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,4 +115,48 @@
     <string name="label_manager">Gestor: %1$s</string>
     <string name="label_status">Estado: %1$s</string>
     <string name="label_task_count">%1$d tarefas</string>
+
+    <!-- Detalhes do Projeto -->
+    <string name="title_project_details">Detalhes do Projeto</string>
+    <string name="label_project_name">Nome do Projeto:</string>
+    <string name="label_project_description">Descrição do Projeto:</string>
+    <string name="label_start">Início:</string>
+    <string name="label_end">Fim:</string>
+    <string name="label_manager_plain">Gestor:</string>
+    <string name="label_collaborators">Colaboradores:</string>
+    <string name="loading_collaborators">(a carregar...)</string>
+    <string name="label_completion_rate">Taxa de Conclusão:</string>
+    <string name="label_time_spent">Tempo Gasto:</string>
+    <string name="action_associate_collaborators">Associar Colaboradores</string>
+    <string name="action_mark_completed">Marcar como concluído</string>
+    <string name="action_delete_project">Apagar Projeto</string>
+    <string name="msg_project_deleted_success">Projeto apagado com sucesso</string>
+    <string name="msg_project_delete_error">Erro ao apagar projeto</string>
+
+    <!-- Avaliação de Projeto -->
+    <string name="title_evaluate_performance">Avaliar Performance</string>
+    <string name="action_save_evaluation">Guardar Avaliação</string>
+    <string name="action_mark_project_complete">Marcar projeto como concluído</string>
+    <string name="msg_invalid_project_data">Dados do projeto inválidos</string>
+    <string name="msg_error_loading_data">Erro ao carregar dados</string>
+    <string name="msg_error_saving_evaluation">Erro ao guardar avaliação</string>
+    <string name="msg_evaluations_saved">Avaliações guardadas!</string>
+    <string name="msg_project_completed">Projeto concluído!</string>
+    <string name="msg_error_completing_project">Erro ao concluir projeto</string>
+
+    <!-- Lista de Projetos -->
+    <string name="title_projects">Projetos</string>
+    <string name="action_add_project">Adicionar projeto</string>
+    <string name="msg_user_not_authenticated">Utilizador não autenticado</string>
+    <string name="msg_error_loading_projects">Erro ao carregar projetos</string>
+    <string name="label_project_manager">Gestor: %1$s</string>
+    <string name="label_project_status">Estado: %1$s</string>
+    <string name="label_project_tasks">%1$d tarefas</string>
+    <string name="action_view">Ver</string>
+    <string name="action_edit">Editar</string>
+    <string name="action_view_tasks">Ver Tarefas</string>
+    <string name="label_rating">Nota:</string>
+    <string name="hint_comment">Comentário</string>
+    <string name="hint_collaborator_task">Nome - Tarefa</string>
+    <string name="none">Nenhum</string>
 </resources>


### PR DESCRIPTION
## Summary
- add missing pt/en strings for project features
- convert hard-coded texts in `ProjectsActivity`, `ProjectDetailsActivity`, and `ProjectEvaluationActivity`
- reference string resources in item layouts
- translate project-related layouts into resources

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684ef2fa9f9483328db7363bb720abe8