### PR TITLE
Add translations for register and task screens

### DIFF
--- a/app/src/main/java/com/example/projetus/ProjectTasksActivity.kt
+++ b/app/src/main/java/com/example/projetus/ProjectTasksActivity.kt
@@ -32,7 +32,7 @@ class ProjectTasksActivity : AppCompatActivity() { // Lista de tarefas do projet
         projectName = intent.getStringExtra("project_name") ?: ""
 
         if (projectId == -1 || userId == -1) { // Validação dos dados
-            Toast.makeText(this, "Erro ao receber dados do projeto", Toast.LENGTH_SHORT).show()
+            Toast.makeText(this, getString(R.string.error_receiving_project_data), Toast.LENGTH_SHORT).show()
             finish()
             return
         }
@@ -79,13 +79,13 @@ class ProjectTasksActivity : AppCompatActivity() { // Lista de tarefas do projet
                         renderTasks(tarefas)
                     } else {
                         Log.e("DEBUG", "Falha na resposta: ${response.errorBody()?.string()}")
-                        Toast.makeText(this@ProjectTasksActivity, "Erro a carregar tarefas", Toast.LENGTH_SHORT).show()
+                        Toast.makeText(this@ProjectTasksActivity, getString(R.string.error_loading_tasks), Toast.LENGTH_SHORT).show()
                     }
                 }
 
                 override fun onFailure(call: Call<TasksResponse>, t: Throwable) {
                     Log.e("DEBUG", "Erro de rede: ${t.message}", t)
-                    Toast.makeText(this@ProjectTasksActivity, "Erro de rede", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this@ProjectTasksActivity, getString(R.string.error_network), Toast.LENGTH_SHORT).show()
                 }
             })
     }

--- a/app/src/main/java/com/example/projetus/RegisterActivity.kt
+++ b/app/src/main/java/com/example/projetus/RegisterActivity.kt
@@ -35,18 +35,18 @@ class RegisterActivity : AppCompatActivity() {
 
             // Verifica se todos os campos foram preenchidos
             if (nome.isEmpty() || user.isEmpty() || mail.isEmpty() || pass.isEmpty()) {
-                Toast.makeText(this, "Preenche todos os campos", Toast.LENGTH_SHORT).show()
+                Toast.makeText(this, getString(R.string.error_fill_all_fields), Toast.LENGTH_SHORT).show()
                 return@setOnClickListener // Encerra se faltarem dados
             }
 
             if (!Patterns.EMAIL_ADDRESS.matcher(mail).matches()) {
-                Toast.makeText(this, "Email inválido", Toast.LENGTH_SHORT).show()
+                Toast.makeText(this, getString(R.string.error_invalid_email), Toast.LENGTH_SHORT).show()
                 return@setOnClickListener
             }
 
             val passwordPattern = Regex("^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&])[A-Za-z\\d@$!%*#?&]{8,}")
             if (!passwordPattern.containsMatchIn(pass)) {
-                Toast.makeText(this, "Palavra-passe fraca", Toast.LENGTH_SHORT).show()
+                Toast.makeText(this, getString(R.string.error_weak_password), Toast.LENGTH_SHORT).show()
                 return@setOnClickListener
             }
 
@@ -68,13 +68,13 @@ class RegisterActivity : AppCompatActivity() {
                         Toast.makeText(this@RegisterActivity, response.body()?.message, Toast.LENGTH_SHORT).show()
                         finish() // Termina Activity em caso de sucesso
                     } else {
-                        Toast.makeText(this@RegisterActivity, response.body()?.message ?: "Erro no registo", Toast.LENGTH_LONG).show()
+                        Toast.makeText(this@RegisterActivity, response.body()?.message ?: getString(R.string.error_registration), Toast.LENGTH_LONG).show()
                     }
                 }
 
                 // Chamado quando ocorre um erro de rede
                 override fun onFailure(call: Call<GenericResponse>, t: Throwable) {
-                    Toast.makeText(this@RegisterActivity, "Erro: ${t.message}", Toast.LENGTH_LONG).show()
+                    Toast.makeText(this@RegisterActivity, getString(R.string.error_generic, t.message), Toast.LENGTH_LONG).show()
                 }
             })
         }

--- a/app/src/main/res/layout/activity_project_tasks.xml
+++ b/app/src/main/res/layout/activity_project_tasks.xml
@@ -12,7 +12,7 @@
         android:id="@+id/tv_titulo"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Tarefas do Projeto"
+        android:text="@string/title_project_tasks"
         android:textSize="24sp"
         android:textStyle="bold" />
 
@@ -21,7 +21,7 @@
         android:id="@+id/tv_nome_projeto"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Nome do Projeto"
+        android:text="@string/placeholder_project_name"
         android:textSize="18sp"
         android:layout_marginTop="8dp" />
 
@@ -51,7 +51,7 @@
             android:layout_height="48dp"
             android:layout_weight="1"
             android:src="@drawable/ic_home"
-            android:contentDescription="Home"
+            android:contentDescription="@string/desc_home"
             android:scaleType="centerInside"
             android:padding="8dp"/>
 
@@ -61,7 +61,7 @@
             android:layout_height="48dp"
             android:layout_weight="1"
             android:src="@drawable/ic_user"
-            android:contentDescription="Perfil"
+            android:contentDescription="@string/desc_profile"
             android:scaleType="centerInside"
             android:padding="8dp"/>
 
@@ -71,7 +71,7 @@
             android:layout_height="48dp"
             android:layout_weight="1"
             android:src="@drawable/ic_settings"
-            android:contentDescription="Configurações"
+            android:contentDescription="@string/desc_settings"
             android:scaleType="centerInside"
             android:padding="8dp"/>
     </LinearLayout>

--- a/app/src/main/res/layout/activity_register.xml
+++ b/app/src/main/res/layout/activity_register.xml
@@ -16,7 +16,7 @@
             android:layout_width="@dimen/logo_size"
             android:layout_height="@dimen/logo_size"
             android:src="@drawable/logo_projetus"
-            android:contentDescription="Logo"
+            android:contentDescription="@string/desc_logo"
             android:layout_marginTop="16dp"
             android:layout_marginBottom="16dp" />
 
@@ -25,7 +25,7 @@
             android:id="@+id/et_fullname"
             android:layout_width="match_parent"
             android:layout_height="50dp"
-            android:hint="Nome completo"
+            android:hint="@string/hint_full_name"
             android:background="@drawable/edittext_background"
             android:padding="12dp"
             android:layout_marginBottom="12dp" />
@@ -35,7 +35,7 @@
             android:id="@+id/et_username"
             android:layout_width="match_parent"
             android:layout_height="50dp"
-            android:hint="Nome de utilizador"
+            android:hint="@string/hint_username"
             android:background="@drawable/edittext_background"
             android:padding="12dp"
             android:layout_marginBottom="12dp" />
@@ -45,7 +45,7 @@
             android:id="@+id/et_email"
             android:layout_width="match_parent"
             android:layout_height="50dp"
-            android:hint="Email"
+            android:hint="@string/hint_email"
             android:inputType="textEmailAddress"
             android:background="@drawable/edittext_background"
             android:padding="12dp"
@@ -56,7 +56,7 @@
             android:id="@+id/et_password"
             android:layout_width="match_parent"
             android:layout_height="50dp"
-            android:hint="Palavra-passe"
+            android:hint="@string/hint_password"
             android:inputType="textPassword"
             android:background="@drawable/edittext_background"
             android:padding="12dp"
@@ -71,14 +71,14 @@
             android:background="@drawable/circle_background"
             android:padding="16dp"
             android:layout_marginBottom="16dp"
-            android:contentDescription="Adicionar foto" />
+            android:contentDescription="@string/desc_add_photo" />
 
         <!-- Botão Criar -->
         <Button
             android:id="@+id/btn_register"
             android:layout_width="match_parent"
             android:layout_height="50dp"
-            android:text="Criar"
+            android:text="@string/action_register"
             android:textColor="#FFFFFF"
             android:backgroundTint="#14AD1A"
             android:layout_marginBottom="16dp" />
@@ -88,7 +88,7 @@
             android:id="@+id/tv_go_to_login"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Já tens conta?"
+            android:text="@string/already_have_account"
             android:textColor="#1976D2"
             android:textSize="14sp"
             android:layout_marginTop="8dp" />

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -158,4 +158,18 @@
     <string name="hint_comment">Comment</string>
     <string name="hint_collaborator_task">Name - Task</string>
     <string name="none">None</string>
+
+    <!-- Registration and task lists -->
+    <string name="action_register">Create</string>
+    <string name="already_have_account">Already have an account?</string>
+    <string name="error_registration">Registration error</string>
+
+    <!-- Project Tasks screen -->
+    <string name="title_project_tasks">Project Tasks</string>
+    <string name="placeholder_project_name">Project Name</string>
+    <string name="error_receiving_project_data">Error receiving project data</string>
+
+    <!-- Accessibility descriptions -->
+    <string name="desc_logo">Logo</string>
+    <string name="desc_add_photo">Add photo</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -159,4 +159,18 @@
     <string name="hint_comment">Comentário</string>
     <string name="hint_collaborator_task">Nome - Tarefa</string>
     <string name="none">Nenhum</string>
+
+    <!-- Registo e listas de tarefas -->
+    <string name="action_register">Criar</string>
+    <string name="already_have_account">Já tens conta?</string>
+    <string name="error_registration">Erro no registo</string>
+
+    <!-- Ecrã de Tarefas do Projeto -->
+    <string name="title_project_tasks">Tarefas do Projeto</string>
+    <string name="placeholder_project_name">Nome do Projeto</string>
+    <string name="error_receiving_project_data">Erro ao receber dados do projeto</string>
+
+    <!-- Descrições de acessibilidade -->
+    <string name="desc_logo">Logo</string>
+    <string name="desc_add_photo">Adicionar foto</string>
 </resources>


### PR DESCRIPTION
## Summary
- internationalize RegisterActivity and ProjectTasksActivity
- add missing string resources for new translations
- update layouts to use resource strings

## Testing
- `./gradlew test` *(fails: Unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684ef687f39c83328f5880aae1c25d5b